### PR TITLE
Cython Kalah

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,145 @@
+# Workflow to build and test wheels
+name: Wheel builder
+
+on:
+  workflow_dispatch
+
+jobs:
+  # Build the wheels for Linux, Windows and macOS for Python 3.8 and newer
+  build_wheels:
+    name: Build wheel for cp${{ matrix.python }}-${{ matrix.platform_id }}-${{ matrix.manylinux_image }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        include:
+          # Window 64 bit
+          # Note: windows-2019 is needed for older Python versions:
+          # https://github.com/scikit-learn/scikit-learn/issues/22530
+          - os: windows-2019
+            python: 38
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 39
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 310
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 311
+            platform_id: win_amd64
+
+          # Linux 64 bit manylinux2014
+          - os: ubuntu-latest
+            python: 38
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 39
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+
+          # NumPy on Python 3.10 only supports 64bit and is only available with manylinux2014
+          - os: ubuntu-latest
+            python: 310
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+
+          - os: ubuntu-latest
+            python: 311
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+
+          # MacOS x86_64
+          - os: macos-latest
+            python: 38
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 39
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 310
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 311
+            platform_id: macosx_x86_64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'  # update once build dependencies are available
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.12.1
+        env:
+          CIBW_BEFORE_BUILD: python -m pip install cython
+          CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
+          CIBW_ARCHS: all
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
+          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_image }}
+        with:
+            output-dir: wheels/wheelhouse/
+            
+      - name: Store artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: wheels/wheelhouse/*.whl
+
+  # Build the source distribution under Linux
+  build_sdist:
+    name: Source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'  # update once build dependencies are available
+
+      - name: Install dependencies  
+        run: |
+            pip install -U pip setuptools wheel cython
+            python setup.py sdist --dist-dir wheels
+
+      - name: Store artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: wheels/*.tar.gz
+
+
+            
+# Upload the wheels and the source distribution
+  upload_wheels:
+    name: Upload wheels
+    runs-on: ubuntu-latest
+    needs: [build_wheels, build_sdist]
+ 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: wheels
+
+      - name: Unpack artifacts
+        run: mkdir wheels/wheelhouse && mv wheels/artifact/*.whl wheels/wheelhouse/ && mv wheels/artifact/*.tar.gz wheels && rmdir wheels/artifact
+
+      - name: Add & Commit
+        uses: EndBug/add-and-commit@v9.1.1
+        with:
+            author_name: BipBop
+            author_email: kmma@fh.4eva
+            message: "Add source"
+            add: "wheels/*"
+

--- a/battler.py
+++ b/battler.py
@@ -82,7 +82,14 @@ class Battler:
 
     def _battle(self, files_n_funcs: Tuple[Tuple[str, Callable]]) -> Tuple[Tuple[str, str], Tuple[float, float]]:
         files, funcs = zip(*files_n_funcs)
-        score = getattr(self.__c(*funcs), self.__f)() if self.__c else self.__f(*funcs)
+        try:
+            # cython __cinit__
+            score = getattr(self.__c.__new__(self.__c, *funcs), self.__f)() if self.__c else self.__f(*funcs)
+        except AttributeError:
+            # python __init__ as a fallback
+            score = getattr(self.__c(*funcs), self.__f)() if self.__c else self.__f(*funcs)
+        except Exception:
+            score = 0, 0
         return files, score
 
     @staticmethod

--- a/kalah.pyx
+++ b/kalah.pyx
@@ -1,0 +1,108 @@
+# cython: language_level=3, boundscheck=False
+
+cdef inline void transfer_stones(list state, int pos, char* trt) noexcept:
+    cdef char num_stones = state[pos]
+    cdef int i
+    state[pos], pos = 0, trt[pos]
+    for i in range(num_stones):
+        state[pos] += 1
+        pos = trt[pos]
+
+DEF __h = 7
+DEF __depth = 5
+cdef char[13] __trt13 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0]
+cdef char[14] __trt6 = [1, 2, 3, 4, 5, 7, 100, 8, 9, 10, 11, 12, 13, 0]
+cdef list __zer = [0, 0, 0, 0, 0, 0]
+
+cdef class Kalah:
+    cdef list current_state
+    cdef bint player
+    cdef object f1, f2
+
+    def __cinit__(self, f1, f2):
+        self.current_state = [6, 6, 6, 6, 6, 6, 0, 6, 6, 6, 6, 6, 6, 0]
+        self.player = 0
+        self.f1 = f1
+        self.f2 = f2
+
+    cdef char _is_end(self) noexcept:
+        if not sum(self.current_state[:6]):
+            self.current_state[13] = 72 - self.current_state[6]
+            self.current_state[7:13] = __zer
+            return 1
+        elif not sum(self.current_state[7:13]):
+            self.current_state[6] = 72 - self.current_state[13]
+            self.current_state[:6] = __zer
+            return 1
+        return 0
+
+    cdef (short, char) max_alpha_beta(self, char deep, short alpha, short beta):
+        cdef int i
+        cdef short maxv = -1990
+        cdef char h = -1
+        cdef list tmp
+
+        if deep == __depth or self._is_end():
+            return (self.f2 if self.player else self.f1)(self.current_state.copy()), 0
+
+        for i in range(6):
+            if self.current_state[i]:
+                tmp = self.current_state.copy()
+                transfer_stones(self.current_state, i, __trt13)
+
+                m = self.min_alpha_beta(deep + 1, alpha, beta)
+                if m > maxv:
+                    maxv = m
+                    h = i
+                self.current_state = tmp
+
+                if maxv >= beta:
+                    return maxv, h
+
+                if maxv > alpha:
+                    alpha = maxv
+
+        return maxv, h
+
+    cdef short min_alpha_beta(self, char deep, short alpha, short beta):
+        cdef int i
+        cdef short minv = 1990
+        cdef list tmp
+        cdef char _
+
+        if deep == __depth or self._is_end():
+            return (self.f2 if self.player else self.f1)(self.current_state.copy())
+
+        for i in range(7, 13):
+            if self.current_state[i]:
+                tmp = self.current_state.copy()
+                transfer_stones(self.current_state, i, __trt6)
+
+                m, _ = self.max_alpha_beta(deep + 1, alpha, beta)
+                if m < minv:
+                    minv = m
+
+                self.current_state = tmp
+
+                if minv <= alpha:
+                    return minv
+
+                if minv < beta:
+                    beta = minv
+
+        return minv
+
+    def play_alpha_beta(self) -> tuple[float, float]:
+        cdef short h, _
+
+        while not self._is_end():
+            _, h = self.max_alpha_beta(0, -2000, 2000)
+            transfer_stones(self.current_state, h, __trt13)
+
+            self.current_state[:__h], self.current_state[__h:] = \
+                self.current_state[__h:], self.current_state[:__h]
+            self.player ^= 1
+
+        if self.current_state[6] == self.current_state[13]:
+            return .5, .5
+        return (0, 1) if self.current_state[6] < self.current_state[13] ^ self.player else (1, 0)


### PR DESCRIPTION
This PR introduces Cython extention of Kalah game class. 

Speed improvement is ~30%

Also adds Github action, which builds wheels for different Python versions and OSes and a source package. The action is activated on demand (manually). To install wheel simply run `pip install <your_python_your_os>.whl`, source package is installed the same way `pip install *.tar.gz`, but the wheel will also be built in the process.

Auto built wheels are placed under `wheels/wheelhouse/*.whl`, and the source package is under `wheels/*.tar.gz`

The reason behind wheels building is that Cython extention must be built. It is built automatically and then shipped as wheel. In order to install from source, one has to have Cython, which can be installed via `pip install cython`

To use the installed module simply import it as a standart python module